### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all: build
+
+
+build: replication.proto
+	protoc --go_out=lib/go --go_opt=paths=source_relative *.proto
+	protoc --go-grpc_out=lib/go --go-grpc_opt=paths=source_relative *.proto


### PR DESCRIPTION
There has been a change in the protoc binary from version v1.12. For
more information refer to:
https://github.com/golang/protobuf/issues/1070.

This Makefile has been kept minimal to achieve the following:

1. Changes should be made to the replication.proto file in the root of
   the repo.
2. The generated code is split into two files now,
   lib/go/replication.pb.go and lib/go/replication_grpc.pb.go

TODO: Add validation methods to ensure that the generated files match
with the commited files.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>