### PR TITLE
Fix `.mergify.yml` validation errors

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,8 +3,6 @@ defaults:
   actions:
     queue:
       name: default
-      method: rebase
-      update_method: rebase
 
 queue_rules:
   - name: default


### PR DESCRIPTION
## AI-generated fix — review carefully before merging

Mergify detected that your `.mergify.yml` was failing schema validation and produced this fix on attempt 2.

**Please review the diff carefully.** The AI may have made changes beyond the strict minimum needed to fix the validation error, and it does not have the full context of your project.

### Original validation error

```
* Extra inputs are not permitted @ root → defaults → actions → queue → method → rebase
* Extra inputs are not permitted @ root → defaults → actions → queue → update_method → rebase
```

---

*Generated by Mergify's AI-assisted configuration fix.*
